### PR TITLE
Change run_on_change to run_on_changes to fix a deprecation warning.

### DIFF
--- a/lib/guard/compass.rb
+++ b/lib/guard/compass.rb
@@ -96,7 +96,7 @@ module Guard
     end
 
     # Compile the changed stylesheets
-    def run_on_change(paths)
+    def run_on_changes(paths)
       perform
     end
 


### PR DESCRIPTION
```
DEPRECATION: Starting with Guard v1.1 the use of the 'run_on_change' method in the 'Guard::Compass' guard is deprecated.
Please consider replacing that method-call with 'run_on_changes' if the type of change
is not important for your usecase or using either 'run_on_modifications' or 'run_on_additions'
based on the type of the changes you want to handle.
```

Fix this deprecation warning by changing `run_on_change` to `run_on_changes`.
